### PR TITLE
Define totalIntensity

### DIFF
--- a/src/forecast.coffee
+++ b/src/forecast.coffee
@@ -167,6 +167,7 @@ module.exports = (robot) ->
       # in the weather
 
       mostIntenseDataPoint = {}
+      totalIntensity = 0
 
       dataPoints = json['minutely']['data']
 


### PR DESCRIPTION
Fixes #5 

The reason that it was sporadic in manifesting was that you only get into this code path if (a) there's "weather", (b) it's "continuing" and (c) it's been less than three hours than the first time you were told about it. Guess I was just luck/unlucky enough to try and set this up on a stormy evening and thus it looked like the whole plugin was a bit broken! :stuck_out_tongue:
